### PR TITLE
mcp/pkg: jwt_auth.go: Fix authentication bypass when using JWT auth.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+CLAUDE.md
 
 # Test binary, built with `go test -c`
 *.test

--- a/mcp/integration_tests/dolt_reset_soft_test.go
+++ b/mcp/integration_tests/dolt_reset_soft_test.go
@@ -9,16 +9,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testDoltResetSoftSetupSQL commits `resetme`, then stages one more row and
+// leaves a third row unstaged. That gives the soft reset a commit to move HEAD
+// off of, plus staged and working changes that the reset must leave alone.
 var testDoltResetSoftSetupSQL = DialectSQL{
 	db.DialectMySQL: `CREATE TABLE resetme (pk int primary key);
 INSERT INTO resetme VALUES (1);
-CALL DOLT_ADD('resetme');
+CALL DOLT_COMMIT('-Am', 'add resetme');
 INSERT INTO resetme VALUES (2);
+CALL DOLT_ADD('resetme');
+INSERT INTO resetme VALUES (3);
 `,
 	db.DialectPostgres: `CREATE TABLE resetme (pk int primary key);
 INSERT INTO resetme VALUES (1);
-SELECT dolt_add('resetme');
+SELECT dolt_commit('-Am', 'add resetme');
 INSERT INTO resetme VALUES (2);
+SELECT dolt_add('resetme');
+INSERT INTO resetme VALUES (3);
 `,
 }
 
@@ -193,24 +200,27 @@ func testDoltResetSoftToolSuccess(s *testSuite, testBranchName string) {
 
 	requireToolExists(s, ctx, client, serverInfo, tools.DoltResetSoftToolName)
 
+	commitHashes, err := getCommitHashes(s, ctx)
+	require.NoError(s.t, err)
+	require.GreaterOrEqual(s.t, len(commitHashes), 2)
+	headBeforeReset, parentOfHead := commitHashes[0], commitHashes[1]
+
+	// Both entries are modifications relative to the setup commit: the staged
+	// row and the unstaged row.
 	tableStatuses, err := getDoltStatus(s, ctx, "resetme")
 	require.NoError(s.t, err)
-
+	require.Len(s.t, tableStatuses, 2)
 	for _, ts := range tableStatuses {
-		if ts.Status == testDoltStatusNewTable {
-			require.True(s.t, ts.Staged)
-		} else if ts.Status == testDoltStatusModifiedTable {
-			require.False(s.t, ts.Staged)
-		}
+		require.Equal(s.t, testDoltStatusModifiedTable, ts.Status)
 	}
 
-	requireTableHasNRows(s, ctx, "resetme", 2)
+	requireTableHasNRows(s, ctx, "resetme", 3)
 
 	doltResetSoftCallToolRequest := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name: tools.DoltResetSoftToolName,
 			Arguments: map[string]any{
-				tools.RevisionCallToolArgumentName:        testBranchName,
+				tools.RevisionCallToolArgumentName:        "HEAD~1",
 				tools.WorkingBranchCallToolArgumentName:   testBranchName,
 				tools.WorkingDatabaseCallToolArgumentName: mcpTestDatabaseName,
 			},
@@ -226,16 +236,25 @@ func testDoltResetSoftToolSuccess(s *testSuite, testBranchName string) {
 	require.NoError(s.t, err)
 	require.Contains(s.t, resultString, "successfully soft reset")
 
+	// The branch HEAD moved back one commit...
+	headAfterReset, err := getLastCommitHash(s, ctx)
+	require.NoError(s.t, err)
+	require.NotEqual(s.t, headBeforeReset, headAfterReset)
+	require.Equal(s.t, parentOfHead, headAfterReset)
+
+	// ...while the staging area and the working set were left alone. The staged
+	// copy of the table now reads as new because HEAD no longer contains it.
 	tableStatuses, err = getDoltStatus(s, ctx, "resetme")
 	require.NoError(s.t, err)
-
+	require.Len(s.t, tableStatuses, 2)
 	for _, ts := range tableStatuses {
 		if ts.Status == testDoltStatusNewTable {
-			require.False(s.t, ts.Staged)
-		} else if ts.Status == testDoltStatusModifiedTable {
+			require.True(s.t, ts.Staged)
+		} else {
+			require.Equal(s.t, testDoltStatusModifiedTable, ts.Status)
 			require.False(s.t, ts.Staged)
 		}
 	}
 
-	requireTableHasNRows(s, ctx, "resetme", 2)
+	requireTableHasNRows(s, ctx, "resetme", 3)
 }

--- a/mcp/integration_tests/helper_test.go
+++ b/mcp/integration_tests/helper_test.go
@@ -37,6 +37,10 @@ var selectLastCommitHashSQL = DialectSQL{
 	db.DialectPostgres: "SELECT commit_hash FROM dolt_log ORDER BY date DESC LIMIT 1;",
 }
 
+// selectCommitHashesSQL selects every commit hash reachable from the current
+// HEAD, most recent first. Identical in both dialects.
+var selectCommitHashesSQL = "SELECT commit_hash FROM dolt_log ORDER BY date DESC;"
+
 type TableStatus struct {
 	Status    string
 	Staged    bool
@@ -119,6 +123,29 @@ func getDoltStatus(s *testSuite, ctx context.Context, tableName string) ([]*Tabl
 	}
 
 	return tableStatuses, nil
+}
+
+func getCommitHashes(s *testSuite, ctx context.Context) ([]string, error) {
+	rows, err := s.testDb.QueryContext(ctx, selectCommitHashesSQL)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	hashes := make([]string, 0)
+	for rows.Next() {
+		var hash string
+		if err := rows.Scan(&hash); err != nil {
+			return nil, err
+		}
+		hashes = append(hashes, hash)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return hashes, nil
 }
 
 func getLastCommitHash(s *testSuite, ctx context.Context) (string, error) {

--- a/mcp/integration_tests/suite.go
+++ b/mcp/integration_tests/suite.go
@@ -36,6 +36,8 @@ const (
 	doltgresRootUserName        = "postgres"
 	doltgresRootPassword        = "password"
 	mcpServerPort               = 8080
+	mcpTestCommitterName        = "dolt-mcp-tests"
+	mcpTestCommitterEmail       = "dolt-mcp-tests@dolthub.com"
 )
 
 var ErrNoDatabaseConnection = errors.New("no database connection")
@@ -228,6 +230,42 @@ func (s *testSuite) Teardown(branchName string, teardownSQL DialectSQL, skipDolt
 	if err != nil {
 		s.t.Fatalf("failed delete branch during test teardown: %s", err.Error())
 	}
+}
+
+// isolateDoltRootPath creates a throwaway dolt root directory and points
+// DOLT_ROOT_PATH at it, so that the dolt/doltgres processes these tests spawn
+// use a known-good global config instead of the one in the developer's home
+// directory. This matters for more than tidiness: if the developer has run
+// `dolt login`, the global config's `user.creds` makes the server send a JWT
+// bearer token to the FileRemoteDatabase's remotesapi, which only accepts basic
+// auth, and every clone/fetch/push/pull test fails to authenticate. The config
+// written here also supplies the committer identity that DOLT_COMMIT requires.
+// Callers own the returned directory and must remove it.
+func isolateDoltRootPath() (string, error) {
+	doltRootPath, err := os.MkdirTemp("", "mcp-server-tests-dolt-root-*")
+	if err != nil {
+		return "", err
+	}
+
+	doltDir := filepath.Join(doltRootPath, ".dolt")
+	if err = os.MkdirAll(doltDir, os.ModePerm); err != nil {
+		return doltRootPath, err
+	}
+
+	globalConfig := fmt.Sprintf(
+		`{"user.name":"%s","user.email":"%s","metrics.disabled":"true","versioncheck.disabled":"true"}`,
+		mcpTestCommitterName,
+		mcpTestCommitterEmail,
+	)
+	if err = os.WriteFile(filepath.Join(doltDir, "config_global.json"), []byte(globalConfig), 0644); err != nil {
+		return doltRootPath, err
+	}
+
+	if err = os.Setenv("DOLT_ROOT_PATH", doltRootPath); err != nil {
+		return doltRootPath, err
+	}
+
+	return doltRootPath, nil
 }
 
 func createMCPDoltServerTestSuite(ctx context.Context, doltBinPath string, dialectType db.DialectType) (*testSuite, error) {

--- a/mcp/integration_tests/suite_test.go
+++ b/mcp/integration_tests/suite_test.go
@@ -33,16 +33,26 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 	}
 
+	// os.Exit below skips deferred cleanup, so every exit path removes this explicitly.
+	doltRootPath, err := isolateDoltRootPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to isolate dolt root path: %v\n", err)
+		os.RemoveAll(doltRootPath)
+		os.Exit(1)
+	}
+
 	suite, err = createMCPDoltServerTestSuite(ctx, doltBinPath, dialectType)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create dolt server test suite: %v\n", err)
 		teardownMCPDoltServerTestSuite(suite)
+		os.RemoveAll(doltRootPath)
 		os.Exit(1)
 	}
 
 	code := m.Run()
 
 	teardownMCPDoltServerTestSuite(suite)
+	os.RemoveAll(doltRootPath)
 
 	os.Exit(code)
 }

--- a/mcp/pkg/jwt_auth.go
+++ b/mcp/pkg/jwt_auth.go
@@ -48,6 +48,7 @@ func withBearerAuth(logger *zap.Logger, next http.Handler, jwkClaimsMap map[stri
 		if err != nil || !valid {
 			logger.Info("unable to authorize jwt", zap.Bool("valid", valid), zap.Error(err))
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
 		}
 
 		next.ServeHTTP(w, r)

--- a/mcp/pkg/jwt_auth_test.go
+++ b/mcp/pkg/jwt_auth_test.go
@@ -1,0 +1,72 @@
+package pkg
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestWithBearerAuth_InvalidToken_DoesNotCallNext demonstrates that when JWT
+// token validation fails, the auth middleware must respond 401 AND stop
+// processing the request. Prior to the fix, the middleware wrote the 401 but
+// forgot to return, so the wrapped handler ran anyway — a full auth bypass.
+func TestWithBearerAuth_InvalidToken_DoesNotCallNext(t *testing.T) {
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	logger := zap.NewNop()
+	// The URL is never fetched: an unparseable token fails before any JWKS
+	// lookup, so this test is deterministic and makes no network calls.
+	claims := map[string]string{"iss": "test-issuer"}
+	handler, err := withBearerAuth(logger, next, claims, "http://127.0.0.1:1/jwks")
+	if err != nil {
+		t.Fatalf("unexpected error building bearer auth handler: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer not-a-valid-jwt")
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rec.Code)
+	}
+	if nextCalled {
+		t.Fatalf("wrapped handler was called despite failed authentication; the request was not rejected")
+	}
+}
+
+// TestWithBearerAuth_MissingToken_DoesNotCallNext is a sanity check that the
+// no-token path (which already returned correctly) still rejects the request.
+func TestWithBearerAuth_MissingToken_DoesNotCallNext(t *testing.T) {
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	logger := zap.NewNop()
+	claims := map[string]string{"iss": "test-issuer"}
+	handler, err := withBearerAuth(logger, next, claims, "http://127.0.0.1:1/jwks")
+	if err != nil {
+		t.Fatalf("unexpected error building bearer auth handler: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rec.Code)
+	}
+	if nextCalled {
+		t.Fatalf("wrapped handler was called despite missing authentication")
+	}
+}

--- a/mcp/pkg/tools/dolt_reset_hard.go
+++ b/mcp/pkg/tools/dolt_reset_hard.go
@@ -11,8 +11,8 @@ import (
 
 const (
 	DoltResetHardToolName                        = "dolt_reset_hard"
-	DoltResetHardToolRevisionArgumentDescription = "The revision to reset to (working set, table name, branch, commit sha, or '.' for all tables)."
-	DoltResetHardToolDescription                 = "Hard resets the working set to the specified revision."
+	DoltResetHardToolRevisionArgumentDescription = "The revision to reset to (a branch name, commit sha, or ancestor spec such as 'HEAD~1'). Table names are not valid revisions."
+	DoltResetHardToolDescription                 = "Hard resets the branch HEAD, staging area, and working set to the specified revision, discarding uncommitted changes."
 	DoltResetHardToolCallSuccessFormatString     = "successfully hard reset: %s"
 )
 

--- a/mcp/pkg/tools/dolt_reset_soft.go
+++ b/mcp/pkg/tools/dolt_reset_soft.go
@@ -11,8 +11,8 @@ import (
 
 const (
 	DoltResetSoftToolName                        = "dolt_reset_soft"
-	DoltResetSoftToolRevisionArgumentDescription = "The revision to reset to (working set, table name, branch, commit sha, or '.' for all tables)."
-	DoltResetSoftToolDescription                 = "Soft resets the working set to the specified revision."
+	DoltResetSoftToolRevisionArgumentDescription = "The revision to move the branch HEAD to (a branch name, commit sha, or ancestor spec such as 'HEAD~1'). Table names are not valid revisions."
+	DoltResetSoftToolDescription                 = "Moves the branch HEAD to the specified revision, leaving the staging area and working set unchanged. To unstage tables instead, use the unstage_table or unstage_all_tables tools."
 	DoltResetSoftToolCallSuccessFormatString     = "successfully soft reset: %s"
 )
 


### PR DESCRIPTION
An incorrectly written auth handler continued processing the request even after writing the 401 header response.